### PR TITLE
Fix Name Error

### DIFF
--- a/core/msfrpc2.py
+++ b/core/msfrpc2.py
@@ -13,6 +13,7 @@
 # see <http://www.gnu.org/licenses/>.
 
 import httplib
+import sys
 try:
     import msgpack
 except:


### PR DESCRIPTION
sys is being used at line 19-20

```
NameError: name 'sys' is not defined
```